### PR TITLE
Fix decoding url

### DIFF
--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -17,7 +17,7 @@ export function Topbar({
   const navigate = useNavigate();
   const { rpc } = useParams({ strict: false });
   const { connected, blockNumber, reset } = useConnectionStore();
-  const currRpc = rpc ? decodeURIComponent(rpc) : "ws://localhost:8545";
+  const currRpc = rpc ? atob(rpc) : "ws://localhost:8545";
 
   const rpcSchema = z.object({
     url: z.string(),
@@ -37,7 +37,7 @@ export function Topbar({
       reset();
     }
     (navigate as any)({
-      to: `/rpc/${encodeURIComponent(newRpc)}`,
+      to: `/rpc/${btoa(newRpc)}`,
       replace: true,
     });
   };
@@ -88,7 +88,7 @@ function SearchBar({ currRpc }: { currRpc: string }) {
 
   const handleSearchSubmit = ({ search }: FieldValues) => {
     const searchTerm = search.trim();
-    const basePath = `/rpc/${encodeURIComponent(currRpc)}`;
+    const basePath = `/rpc/${btoa(currRpc)}`;
 
     if (isAddress(searchTerm)) {
       (navigate as any)({

--- a/src/routes/rpc.$rpc/_l.tsx
+++ b/src/routes/rpc.$rpc/_l.tsx
@@ -11,7 +11,7 @@ import { useConnectionState } from "#/hooks/useConnectionState";
 
 export const Route = createFileRoute("/rpc/$rpc/_l")({
   loader: async ({ params }) => {
-    return decodeURIComponent(params.rpc);
+    return atob(params.rpc);
   },
   component: RouteComponent,
 });

--- a/src/routes/rpc.$rpc/_l/address.$address.tsx
+++ b/src/routes/rpc.$rpc/_l/address.$address.tsx
@@ -18,7 +18,7 @@ import { z } from "zod";
 import { LoadingSpinner } from "#/components/LoadingSpinner";
 
 const searchSchema = z.object({
-  callData: z.string().catch(""),
+  callData: z.string().optional(),
 });
 
 export const Route = createFileRoute("/rpc/$rpc/_l/address/$address")({


### PR DESCRIPTION
Previous decoding method was not working correcttly on refresh, this [https://explorer-self-theta.vercel.app/rpc/ws%3A%2F%2Flocalhost%3A8545](url) would become this on refresh [https://explorer-self-theta.vercel.app/rpc/ws:/localhost:8545](url), therefore not working corretly.

Changed to base64